### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 ![antd-components-mcp](https://socialify.git.ci/zhixiaoqiang/antd-components-mcp/image?description=1&font=Inter&forks=1&issues=1&language=1&name=1&owner=1&pattern=Plus&pulls=1&stargazers=1&theme=Light)
 
+<a href="https://glama.ai/mcp/servers/@zhixiaoqiang/antd-components-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zhixiaoqiang/antd-components-mcp/badge" alt="antd-components-mcp MCP server" />
+</a>
+
 [![npm version](https://img.shields.io/npm/v/@jzone-mcp/antd-components-mcp.svg)](https://www.npmjs.com/package/@jzone-mcp/antd-components-mcp)
 
 <center>


### PR DESCRIPTION
This PR adds a badge for the [antd-components-mcp](https://glama.ai/mcp/servers/@zhixiaoqiang/antd-components-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zhixiaoqiang/antd-components-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zhixiaoqiang/antd-components-mcp/badge" alt="antd-components-mcp MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.