### PR TITLE
feat: Enhance listComponentExamples to prioritize remote fetching wit…

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,12 +55,14 @@
   "license": "MIT",
   "dependencies": {
     "@modelcontextprotocol/sdk": "latest",
+    "node-fetch": "^2.7.0",
     "to-vfile": "^8.0.0",
     "vfile-matter": "^5.0.1",
     "zod": "^3.24.2"
   },
   "devDependencies": {
     "@types/node": "^22.13.14",
+    "@types/node-fetch": "^2.6.12",
     "tsup": "^8.4.0",
     "tsx": "^4.19.3",
     "typescript": "^5.8.2"


### PR DESCRIPTION
…h local fallback

- Add language parameter to support localized example fetching (default: 'zh-CN')
- Implement remote fetching from Ant Design GitHub repository
- Cache remote example content for improved performance
- Maintain local fallback mechanism for robustness